### PR TITLE
This is a fix for issue #9 - it adds  <win-app-bar-content>  element

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Examples of control usage
 
     <win-tool-bar>
         <win-tool-bar-command label="'This is a ToolBar command'" icon="'add'"></win-tool-bar-command>
+        <win-app-bar-separator></win-app-bar-separator>
         <win-tool-bar-content>
             <win-search-box placeholder-text="'Search'"></win-search-box>
         </win-tool-bar-content>

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Examples of control usage
 
     <!-- Shows up on the bottom of the screen, use right-click or touch edgy gesture to show -->
     <win-app-bar>
-	    <win-app-bar-command icon="'home'" label="'Home'"></win-app-bar-command>
+        <win-app-bar-command icon="'home'" label="'Home'"></win-app-bar-command>
         <win-app-bar-separator></win-app-bar-separator>
         <win-app-bar-command icon="'save'" label="'Save'"></win-app-bar-command>
-	    <win-app-bar-content>
+        <win-app-bar-content>
             <win-search-box placeholder-text="'Search'"></win-search-box>
-	    </win-app-bar-content>
-	</win-app-bar>
+        </win-app-bar-content>
+    </win-app-bar>
 
 ### DatePicker
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ Examples of control usage
 
     <win-tool-bar>
         <win-tool-bar-command label="'This is a ToolBar command'" icon="'add'"></win-tool-bar-command>
+        <win-tool-bar-content>
+            <win-search-box placeholder-text="'Search'"></win-search-box>
+        </win-tool-bar-content>
     </win-tool-bar>
 
 ### TimePicker

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Examples of control usage
     <!-- Shows up on the bottom of the screen, use right-click or touch edgy gesture to show -->
     <win-app-bar>
 	    <win-app-bar-command icon="'home'" label="'Home'"></win-app-bar-command>
+        <win-app-bar-separator></win-app-bar-separator>
         <win-app-bar-command icon="'save'" label="'Save'"></win-app-bar-command>
 	    <win-app-bar-content>
             <win-search-box placeholder-text="'Search'"></win-search-box>
@@ -146,7 +147,7 @@ Examples of control usage
 
     <win-tool-bar>
         <win-tool-bar-command label="'This is a ToolBar command'" icon="'add'"></win-tool-bar-command>
-        <win-app-bar-separator></win-app-bar-separator>
+        <win-tool-bar-separator></win-tool-bar-separator>
         <win-tool-bar-content>
             <win-search-box placeholder-text="'Search'"></win-search-box>
         </win-tool-bar-content>

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ Examples of control usage
 
     <!-- Shows up on the bottom of the screen, use right-click or touch edgy gesture to show -->
     <win-app-bar>
-        <win-app-bar-command icon="'home'" label="'Home'"></win-app-bar-command>
+	    <win-app-bar-command icon="'home'" label="'Home'"></win-app-bar-command>
         <win-app-bar-command icon="'save'" label="'Save'"></win-app-bar-command>
-    </win-app-bar>
+	    <win-app-bar-content>
+            <win-search-box placeholder-text="'Search'"></win-search-box>
+	    </win-app-bar-content>
+	</win-app-bar>
 
 ### DatePicker
 

--- a/js/angular-winjs.js
+++ b/js/angular-winjs.js
@@ -1447,6 +1447,35 @@
         };
     });
 
+    exists("ToolBar") && module.directive("winToolBarSeparator", function () {
+        var api = {
+            disabled: BINDING_property,
+            extraClass: BINDING_property,
+            firstElementFocus: BINDING_property,
+            flyout: BINDING_property,
+            hidden: BINDING_property,
+            icon: BINDING_property,
+            id: BINDING_property,
+            label: BINDING_property,
+            lastElementFocus: BINDING_property,
+            section: BINDING_property,
+            selected: BINDING_property,
+            tooltip: BINDING_property,
+            type: BINDING_property,
+            onClick: BINDING_event
+        };
+        return {
+            restrict: "E",
+            replace: true,
+            scope: getScopeForAPI(api),
+            template: "<HR ng-transclude='true'></HR>",
+            transclude: true,
+            link: function ($scope, elements) {
+                initializeControl($scope, elements[0], WinJS.UI.Command, api, { type: "separator" });
+            }
+        };
+    });
+
     exists("ToolBar") && module.directive("winToolBarContent", function () {
         var api = {
             disabled: BINDING_property,

--- a/js/angular-winjs.js
+++ b/js/angular-winjs.js
@@ -1418,6 +1418,35 @@
         };
     });
 
+    exists("ToolBar") && module.directive("winToolBarContent", function () {
+        var api = {
+            disabled: BINDING_property,
+            extraClass: BINDING_property,
+            firstElementFocus: BINDING_property,
+            flyout: BINDING_property,
+            hidden: BINDING_property,
+            icon: BINDING_property,
+            id: BINDING_property,
+            label: BINDING_property,
+            lastElementFocus: BINDING_property,
+            section: BINDING_property,
+            selected: BINDING_property,
+            tooltip: BINDING_property,
+            type: BINDING_property,
+            onClick: BINDING_event
+        };
+        return {
+            restrict: "E",
+            replace: true,
+            scope: getScopeForAPI(api),
+            template: "<DIV ng-transclude='true'></DIV>",
+            transclude: true,
+            link: function ($scope, elements) {
+                initializeControl($scope, elements[0], WinJS.UI.Command, api, { type: "content" });
+            }
+        };
+    });
+
     exists("Tooltip") && module.directive("winTooltip", function () {
         var api = {
             contentElement: BINDING_property,

--- a/js/angular-winjs.js
+++ b/js/angular-winjs.js
@@ -490,6 +490,35 @@
         };
     });
 
+    exists("AppBar") && module.directive("winAppBarContent", function () {
+        var api = {
+            disabled: BINDING_property,
+            extraClass: BINDING_property,
+            firstElementFocus: BINDING_property,
+            flyout: BINDING_property,
+            hidden: BINDING_property,
+            icon: BINDING_property,
+            id: BINDING_property,
+            label: BINDING_property,
+            lastElementFocus: BINDING_property,
+            section: BINDING_property,
+            selected: BINDING_property,
+            tooltip: BINDING_property,
+            type: BINDING_property,
+            onClick: BINDING_event
+        };
+        return {
+            restrict: "E",
+            replace: true,
+            scope: getScopeForAPI(api),
+            template: "<DIV ng-transclude='true'></DIV>",
+            transclude: true,
+            link: function ($scope, elements) {
+                initializeControl($scope, elements[0], WinJS.UI.Command, api, { type: "content" });
+            }
+        };
+    });
+
     exists("BackButton") && module.directive("winBackButton", function () {
         return {
             restrict: "E",


### PR DESCRIPTION
This is a fix for issue #9 - it adds `<win-app-bar-content>` element to allow custom content in AppBar (in same way as `<win-app-bar-separator>`).
Plus `<win-tool-bar-separator>` and `<win-tool-bar-content>` elements have been added.
And examples of all this elements added to the README.md file.