### PR TITLE
Check to see if MSApp.execUnsafeLocalFunction exists

### DIFF
--- a/js/angular-winjs.js
+++ b/js/angular-winjs.js
@@ -380,7 +380,7 @@
         var Scope$eval = Scope.$eval;
         Scope.$eval = function (expr, locals) {
             var that = this;
-            if (window.MSApp) {
+            if (window.MSApp && MSApp.execUnsafeLocalFunction) {
                 return MSApp.execUnsafeLocalFunction(function () {
                     return Scope$eval.call(that, expr, locals);
                 });


### PR DESCRIPTION
Angular-Winjs crashes in a UWP, because MSApp.execUnsafeLocalFunction is undefined. It seems to be removed in Windows 10.

Added a check to see if MSApp.execUnsafeLocalFunction exists. [Winstore-jscompat](https://github.com/MSOpenTech/winstore-jscompat) does this check too.

