### PR TITLE
Add winAutoSuggestBox directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Examples of control usage
             <win-search-box placeholder-text="'Search'"></win-search-box>
         </win-app-bar-content>
     </win-app-bar>
+
+### AutoSuggestionBox
+
+    The current query text is: {{queryText}}.<br/>
+    <win-auto-suggest-box query-text="queryText"></win-auto-suggest-box>
+
     
 ### Content Dialog
 

--- a/js/angular-winjs.js
+++ b/js/angular-winjs.js
@@ -518,6 +518,36 @@
             }
         };
     });
+    
+    exists("AutoSuggestBox") && module.directive("winAutoSuggestBox", function () {
+        var api = {
+            chooseSuggestionOnEnter: BINDING_property,
+            disabled: BINDING_property,
+            placeholderText: BINDING_property,
+            queryText: BINDING_property,
+            searchHistoryContext: BINDING_property,
+            searchHistoryDisabled: BINDING_property,
+            onQueryChanged: BINDING_event,
+            onQuerySubmitted: BINDING_event,
+            onResultSuggestionChosen: BINDING_event,
+            onSuggestionsRequested: BINDING_event
+        };
+        return {
+            restrict: "E",
+            replace: true,
+            scope: getScopeForAPI(api),
+            template: "<DIV></DIV>",
+            link: function ($scope, elements, attrs) {
+                var control = initializeControl($scope, elements[0], WinJS.UI.AutoSuggestBox, api);
+
+                control.addEventListener("querychanged", function () {
+                    apply($scope, function () {
+                        $scope["queryText"] = control["queryText"];
+                    });
+                });
+            }
+        };
+    });
 
     exists("BackButton") && module.directive("winBackButton", function () {
         return {

--- a/tests/AutoSuggestBox.js
+++ b/tests/AutoSuggestBox.js
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corp.  All Rights Reserved. Licensed under the MIT License. See License.txt in the project root for license information.
+
+describe("AutoSuggestBox control directive tests", function () {
+    var scope,
+        compile;
+
+    beforeEach(angular.mock.module("winjs"));
+    beforeEach(angular.mock.inject(function ($rootScope, $compile) {
+        scope = $rootScope.$new();
+        compile = $compile;
+    }));
+
+    function initControl(markup) {
+        var element = angular.element(markup)[0];
+        document.body.appendChild(element);
+        var compiledControl = compile(element)(scope)[0];
+        scope.$digest();
+        return compiledControl;
+    }
+
+    it("should initialize a simple autosuggestbox", function () {
+        var compiledControl = initControl("<win-auto-suggest-box></win-auto-suggest-box>");
+        
+        expect(compiledControl.winControl).toBeDefined();
+        expect(compiledControl.winControl instanceof WinJS.UI.AutoSuggestBox);
+        expect(compiledControl.className).toContain("win-autosuggestbox");
+    });
+
+    it("should use the chooseSuggestionOnEnter attribute", function () {
+        var compiledControl = initControl("<win-auto-suggest-box choose-suggestion-on-enter='true'></win-auto-suggest-box>");
+        expect(compiledControl.winControl.chooseSuggestionOnEnter).toBeTruthy();
+    });
+	
+    it("should use the placeholderText attribute", function () {
+        var compiledControl = initControl("<win-auto-suggest-box placeholder-text=\"'Some Placeholder Text'\"></win-auto-suggest-box>");
+        expect(compiledControl.winControl.placeholderText).toEqual("Some Placeholder Text");
+    });
+
+    it("should use the queryText attribute", function () {
+        var compiledControl = initControl("<win-auto-suggest-box query-text=\"'Some Query Text'\"></win-auto-suggest-box>");
+        expect(compiledControl.winControl.queryText).toEqual("Some Query Text");
+    });
+
+    it("should use the searchHistoryContext attribute", function () {
+        var compiledControl = initControl("<win-auto-suggest-box search-history-context=\"'searchContext'\"></win-auto-suggest-box>");
+        expect(compiledControl.winControl.searchHistoryContext).toEqual("searchContext");
+    });
+
+    it("should use the searchHistoryDisabled attribute", function () {
+        var compiledControl = initControl("<win-auto-suggest-box search-history-disabled='true'></win-auto-suggest-box>");
+        expect(compiledControl.winControl.searchHistoryDisabled).toBeTruthy();
+    });
+
+    afterEach(function () {
+        var controls = document.querySelectorAll(".win-auto-suggest-box");
+        for (var i = 0; i < controls.length; i++) {
+            controls[i].parentNode.removeChild(controls[i]);
+        }
+    });
+});


### PR DESCRIPTION
Add winAutoSuggestBox directive to make it easy to use new
AutoSuggestBox from WinJS 4.0 preview. Also add tests and an example
to README.md.