### PR TITLE
Fix nested function literal.

### DIFF
--- a/js/angular-winjs.js
+++ b/js/angular-winjs.js
@@ -148,7 +148,7 @@
             }));
 
             var deferUpdate = false;
-            function updateOriginalArray() {
+            var updateOriginalArray = function () {
                 if (deferUpdate) {
                     return;
                 }


### PR DESCRIPTION
This violates strict-mode, and breaks Safari on MacOS/iOS.